### PR TITLE
Ensure we properly read the mach header

### DIFF
--- a/NULLGuard/NULLGuard.c
+++ b/NULLGuard/NULLGuard.c
@@ -42,8 +42,7 @@ kern_return_t NULLGuard_stop(kmod_info_t *ki, void *d);
 static int c = 0;
 int nullguard_execve(kauth_cred_t cred, kauth_cred_t new, struct proc* p, struct vnode* vp) {
     struct mach_header* mh = _MALLOC(PAGE_SIZE_64*4, M_TEMP, M_ZERO);
-    get_mach_header(mh, vp);
-    if (mh->magic == MH_MAGIC) {
+    if (get_mach_header(mh, vp) == KERN_SUCCESS && mh->magic == MH_MAGIC) {
         // only 32 bit processes can lack PAGEZERO when uid != 0
         struct load_command *loadCmd = (struct load_command*) (mh + 1);
         for (uint32_t i=0; i < mh->ncmds && ((uint64_t)loadCmd) - ((uint64_t)mh) < PAGE_SIZE_64*4; i++) {

--- a/NULLGuard/NULLGuard.c
+++ b/NULLGuard/NULLGuard.c
@@ -23,6 +23,7 @@ static kern_return_t
 get_mach_header(void *buffer, vnode_t kernel_vnode)
 {
     int error = 0;
+    if(buffer == NULL) return EINVAL;
     
     uio_t uio = NULL;
     uio = uio_create(1, 0, UIO_SYSSPACE, UIO_READ);


### PR DESCRIPTION
Check the return value of get_mach_header.
Because the buffer is zeroed at alloc, it shouldn't be an issue but it doesn't hurt
